### PR TITLE
Fix security issues and high-severity bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,27 @@
-FROM ubuntu:24.10
+FROM python:3.12-slim
 
-LABEL maintainer=""
+LABEL maintainer="tomer.klein@gmail.com"
 
-ENV PYTHONIOENCODING=utf-8
-ENV LANG=C.UTF-8
-
-ENV GREEN_API_INSTANCE_ID ""
-ENV GREEN_API_TOKEN ""
-ENV TARGET ""
-ENV MESSAGE ""
-
-
-RUN apt update -yqq 
-
-RUN apt install -yqq python3-pip && \
-    apt install -yqq libffi-dev && \
-    apt install -yqq libssl-dev
-
-RUN  pip3 install --upgrade setuptools --no-cache-dir
-
-RUN mkdir -p /app/
-
-COPY requirements.txt /tmp
-
-RUN pip3 install -r /tmp/requirements.txt
-
-COPY app /app
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONIOENCODING=utf-8 \
+    LANG=C.UTF-8 \
+    PORT=8000
 
 WORKDIR /app
 
-ENTRYPOINT ["/usr/bin/python3", "/app/app.py"]
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY app /app
+
+# Run as a non-root user on an unprivileged port.
+RUN useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+EXPOSE 8000
+
+ENTRYPOINT ["python3", "/app/app.py"]

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,7 @@
 import os
 import time
+import shutil
+import tempfile
 import uvicorn
 import requests
 import ipaddress
@@ -70,9 +72,11 @@ class Server:
             host_for_url = f"[{client_host}]" if client_ip.version == 6 else client_host
             url = f"http://{host_for_url}/capture"
 
+            # Unique per-request working directory avoids filename collisions
+            # between concurrent triggers and is always cleaned up below.
+            tmpdir = tempfile.mkdtemp(prefix="espcam_")
             try:
-                file_names = [f'image{i+1}.jpg' for i in range(3)]
-
+                saved = []
                 for i in range(3):
                     # Fetch the image. The timeout prevents a hung camera from
                     # blocking the worker indefinitely.
@@ -84,31 +88,34 @@ class Server:
                         continue
                     if response.status_code == 200:
                         # Save the image to a local file
-                        with open(file_names[i], 'wb') as file:
+                        path = os.path.join(tmpdir, f"image{i+1}.jpg")
+                        with open(path, 'wb') as file:
                             file.write(response.content)
-                        logger.info(f"Image saved as {file_names[i]}")
+                        saved.append(path)
+                        logger.info(f"Image saved as {path}")
                     else:
                         logger.error(f"Failed to retrieve image {i+1}: HTTP {response.status_code}")
 
                     # Wait for 1 second before the next request
                     time.sleep(1)
-                
-                #Send the images
-                for i in range(3):
-                    upload_file_response = greenAPI.sending.uploadFile(file_names[i]) 
-                    if upload_file_response.code != 200:
-                        logger.error("Failed to upload file: " + file_names[i])
-                    else:
+
+                # Send only the images that were actually captured.
+                for path in saved:
+                    try:
+                        upload_file_response = greenAPI.sending.uploadFile(path)
+                        if upload_file_response.code != 200:
+                            logger.error("Failed to upload file: " + path)
+                            continue
                         url_file = upload_file_response.data["urlFile"]
-                        logger.debug(url_file)
-                        url = urlparse(url_file)
-                        file_name = basename(url.path)
-                        logger.warning(file_name)
+                        file_name = basename(urlparse(url_file).path)
                         send_file_by_url_response = greenAPI.sending.sendFileByUrl(TARGET, url_file, file_name, caption=MESSAGE)
                         logger.info(send_file_by_url_response)
-                        os.remove(file_names[i])
+                    except Exception as e:
+                        logger.error(f"Failed to send {path}: {e}")
             except Exception as e:
-                logger.error(str(e)) 
+                logger.error(str(e))
+            finally:
+                shutil.rmtree(tmpdir, ignore_errors=True)
             return "OK"
 
     

--- a/app/app.py
+++ b/app/app.py
@@ -16,6 +16,9 @@ GREEN_API_INSTANCE_ID = os.getenv("GREEN_API_INSTANCE_ID")
 GREEN_API_TOKEN = os.getenv("GREEN_API_TOKEN")
 TARGET = os.getenv("TARGET")
 MESSAGE = os.getenv("MESSAGE")
+# Shared secret required to trigger the capture endpoint. If unset the endpoint
+# stays open (bootstrap mode) but a warning is logged on every request.
+AUTH_TOKEN = os.getenv("AUTH_TOKEN")
 greenAPI = API.GreenAPI(GREEN_API_INSTANCE_ID,GREEN_API_TOKEN)
 
 class Server:
@@ -39,8 +42,16 @@ class Server:
             """
             Get Images
             """
+            # Authenticate before doing any work. Kept outside the try/except
+            # below so the 401 is not swallowed and turned into "OK".
+            if AUTH_TOKEN:
+                provided = request.headers.get("X-Auth-Token") or request.query_params.get("token")
+                if provided != AUTH_TOKEN:
+                    raise HTTPException(status_code=401, detail="Unauthorized")
+            else:
+                logger.warning("AUTH_TOKEN not set - capture endpoint is UNAUTHENTICATED")
+
             try:
-                time.sleep(1)
                 client_host = request.client.host
                 ipv4_address = str(client_host)
                 ip = ipaddress.IPv4Address(ipv4_address)

--- a/app/app.py
+++ b/app/app.py
@@ -51,14 +51,25 @@ class Server:
             else:
                 logger.warning("AUTH_TOKEN not set - capture endpoint is UNAUTHENTICATED")
 
+            # Validate the client address before making any outbound request.
+            # Kept outside the try/except so the error is not turned into "OK".
+            client_host = request.client.host if request.client else None
+            if not client_host:
+                raise HTTPException(status_code=400, detail="Unable to determine client address")
             try:
-                client_host = request.client.host
-                ipv4_address = str(client_host)
-                ip = ipaddress.IPv4Address(ipv4_address)
-                last_octet = ip.packed[-1]
-                # logger.info(client_host)
-                url = f'http://{str(client_host)}/capture'
-                file_names = [f'{last_octet}_image1.jpg', f'{last_octet}_image2.jpg', f'{last_octet}_image3.jpg']
+                client_ip = ipaddress.ip_address(client_host)
+            except ValueError:
+                raise HTTPException(status_code=400, detail="Invalid client address")
+            # Only fetch from a camera on a private/loopback network. This stops
+            # the server from being coerced into requesting arbitrary external
+            # hosts (SSRF).
+            if not client_ip.is_private:
+                raise HTTPException(status_code=403, detail="Camera must be on a private network")
+            host_for_url = f"[{client_host}]" if client_ip.version == 6 else client_host
+            url = f"http://{host_for_url}/capture"
+
+            try:
+                file_names = [f'image{i+1}.jpg' for i in range(3)]
 
                 for i in range(3):
                     # Make the request to fetch the image

--- a/app/app.py
+++ b/app/app.py
@@ -19,8 +19,8 @@ GREEN_API_INSTANCE_ID = os.getenv("GREEN_API_INSTANCE_ID")
 GREEN_API_TOKEN = os.getenv("GREEN_API_TOKEN")
 TARGET = os.getenv("TARGET")
 MESSAGE = os.getenv("MESSAGE")
-# Shared secret required to trigger the capture endpoint. If unset the endpoint
-# stays open (bootstrap mode) but a warning is logged on every request.
+# Shared secret required to trigger the capture endpoint. Required: when unset
+# the endpoint refuses every request (fail closed).
 AUTH_TOKEN = os.getenv("AUTH_TOKEN")
 # Timeout (seconds) for outbound requests to the camera.
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "10"))
@@ -62,12 +62,12 @@ class Server:
             """
             # Authenticate before doing any work. Kept outside the try/except
             # below so the 401 is not swallowed and turned into "OK".
-            if AUTH_TOKEN:
-                provided = request.headers.get("X-Auth-Token") or request.query_params.get("token") or ""
-                if not hmac.compare_digest(provided, AUTH_TOKEN):
-                    raise HTTPException(status_code=401, detail="Unauthorized")
-            else:
-                logger.warning("AUTH_TOKEN not set - capture endpoint is UNAUTHENTICATED")
+            if not AUTH_TOKEN:
+                logger.error("AUTH_TOKEN not configured - refusing request")
+                raise HTTPException(status_code=503, detail="Server not configured: AUTH_TOKEN is required")
+            provided = request.headers.get("X-Auth-Token") or request.query_params.get("token") or ""
+            if not hmac.compare_digest(provided, AUTH_TOKEN):
+                raise HTTPException(status_code=401, detail="Unauthorized")
 
             # Validate the client address before making any outbound request.
             # Kept outside the try/except so the error is not turned into "OK".

--- a/app/app.py
+++ b/app/app.py
@@ -19,6 +19,8 @@ MESSAGE = os.getenv("MESSAGE")
 # Shared secret required to trigger the capture endpoint. If unset the endpoint
 # stays open (bootstrap mode) but a warning is logged on every request.
 AUTH_TOKEN = os.getenv("AUTH_TOKEN")
+# Timeout (seconds) for outbound requests to the camera.
+REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "10"))
 greenAPI = API.GreenAPI(GREEN_API_INSTANCE_ID,GREEN_API_TOKEN)
 
 class Server:
@@ -72,17 +74,22 @@ class Server:
                 file_names = [f'image{i+1}.jpg' for i in range(3)]
 
                 for i in range(3):
-                    # Make the request to fetch the image
-                    response = requests.get(url)
-                    # Check if the request was successful
+                    # Fetch the image. The timeout prevents a hung camera from
+                    # blocking the worker indefinitely.
+                    try:
+                        response = requests.get(url, timeout=REQUEST_TIMEOUT)
+                    except requests.RequestException as e:
+                        logger.error(f"Failed to fetch image {i+1}: {e}")
+                        time.sleep(1)
+                        continue
                     if response.status_code == 200:
                         # Save the image to a local file
                         with open(file_names[i], 'wb') as file:
                             file.write(response.content)
-                        print(f"Image saved as {file_names[i]}")
+                        logger.info(f"Image saved as {file_names[i]}")
                     else:
-                        print(f"Failed to retrieve image {i+1}")
-                    
+                        logger.error(f"Failed to retrieve image {i+1}: HTTP {response.status_code}")
+
                     # Wait for 1 second before the next request
                     time.sleep(1)
                 

--- a/app/app.py
+++ b/app/app.py
@@ -121,7 +121,7 @@ class Server:
     
   
     def start(self):
-        uvicorn.run(self.app, host="0.0.0.0", port=80)
+        uvicorn.run(self.app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))
         
         
 if __name__=="__main__":

--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,6 @@
 import os
 import time
+import hmac
 import shutil
 import tempfile
 import uvicorn
@@ -49,8 +50,8 @@ class Server:
             # Authenticate before doing any work. Kept outside the try/except
             # below so the 401 is not swallowed and turned into "OK".
             if AUTH_TOKEN:
-                provided = request.headers.get("X-Auth-Token") or request.query_params.get("token")
-                if provided != AUTH_TOKEN:
+                provided = request.headers.get("X-Auth-Token") or request.query_params.get("token") or ""
+                if not hmac.compare_digest(provided, AUTH_TOKEN):
                     raise HTTPException(status_code=401, detail="Unauthorized")
             else:
                 logger.warning("AUTH_TOKEN not set - capture endpoint is UNAUTHENTICATED")

--- a/app/app.py
+++ b/app/app.py
@@ -24,6 +24,19 @@ MESSAGE = os.getenv("MESSAGE")
 AUTH_TOKEN = os.getenv("AUTH_TOKEN")
 # Timeout (seconds) for outbound requests to the camera.
 REQUEST_TIMEOUT = float(os.getenv("REQUEST_TIMEOUT", "10"))
+
+
+def _redact_secrets(record):
+    """Scrub credentials from log messages. The GreenAPI SDK embeds the token
+    in request URLs, so an exception message can otherwise leak it to the logs."""
+    message = record["message"]
+    for secret in (GREEN_API_TOKEN, GREEN_API_INSTANCE_ID, AUTH_TOKEN):
+        if secret:
+            message = message.replace(secret, "***")
+    record["message"] = message
+
+
+logger = logger.patch(_redact_secrets)
 greenAPI = API.GreenAPI(GREEN_API_INSTANCE_ID,GREEN_API_TOKEN)
 
 class Server:

--- a/app/app.py
+++ b/app/app.py
@@ -22,12 +22,15 @@ class Server:
     def __init__(self):
        
         self.app = FastAPI(title="esp32 cam security server", description="Capture and send images taken with esp32 cam", version='1.0.0',  contact={"name": "Tomer Klein", "email": "tomer.klein@gmail.com", "url": "https://github.com/t0mer/espcam-secserver"})
-        self.origins = ["*"]
+        # Only allow the origins explicitly configured via CORS_ORIGINS (comma
+        # separated). Default is no cross-origin access. Never combine a wildcard
+        # origin with credentials.
+        self.origins = [o.strip() for o in os.getenv("CORS_ORIGINS", "").split(",") if o.strip()]
         self.app.add_middleware(
             CORSMiddleware,
             allow_origins=self.origins,
-            allow_credentials=True,
-            allow_methods=["*"],
+            allow_credentials=False,
+            allow_methods=["GET"],
             allow_headers=["*"],
         )
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,5 +9,7 @@ services:
       - GREEN_API_TOKEN= #Green API Token
       - TARGET= #Target phone number 972*********@c.us for contact or @g.us for group
       - MESSAGE= #Caption for the image sent
+      - AUTH_TOKEN= #Shared secret required to trigger the capture endpoint
+      - CORS_ORIGINS= #Optional comma-separated allowed CORS origins
     ports:
-      - "80:80"
+      - "80:8000"


### PR DESCRIPTION
Fixes the security issues and high-severity bugs found in a review of the capture server and container.

## Security
- **Auth required (fail closed):** `GET /` now requires a shared secret via `X-Auth-Token` header or `?token=`. When `AUTH_TOKEN` is unset the endpoint refuses every request (`503`). Comparison is constant-time (`hmac.compare_digest`).
- **SSRF guard:** the client address is validated and images are only fetched from cameras on a private/loopback network. IPv6 peers are parsed safely (previously crashed) and bracketed in the URL.
- **CORS:** dropped `allow_origins=["*"]` + `allow_credentials=True`; origins now come from `CORS_ORIGINS` (default none), credentials off, methods limited to `GET`.
- **Non-root container:** `python:3.12-slim` base, dedicated `appuser`, unprivileged port `8000` (host `80:8000` in compose). Also fixes the `ubuntu:24.10` PEP-668 build break.
- **Log redaction:** credentials (GreenAPI token/instance id, auth token) are scrubbed from all log output, so an SDK exception URL can't leak the token.

## High bugs
- **Request timeout + network error handling** when fetching camera images (was unbounded → worker hang / DoS).
- **Robust file lifecycle:** unique per-request temp dir (no filename collisions between concurrent triggers), upload only images that were actually captured, and always clean up (no leaked `.jpg` files on failure).

## Notes
- `AUTH_TOKEN` must be set for the service to work now (fail-closed, chosen deliberately). The ESP32 firmware must send the token; the door-open trigger URL in `CameraWebServer.ino` is still an empty placeholder and needs the backend URL + token filled in (out of scope here).
- Not addressed (pre-existing, lower priority): the stock ESP32 `app_httpd.cpp` exposes an unauthenticated stream/control interface on the LAN; unpinned `requirements.txt`; outdated GitHub Actions workflow.